### PR TITLE
Add quit and exit commands to CLI

### DIFF
--- a/src/hotaru/hotaru.py
+++ b/src/hotaru/hotaru.py
@@ -232,5 +232,7 @@ def cli() -> None:
             elif query[0] == "new":
                 state = State()
                 break
+            elif query[0] in ("quit", "exit"):
+                return
             else:
                 print("Unknown command")


### PR DESCRIPTION
## Summary
Added support for "quit" and "exit" commands in the CLI to allow users to gracefully exit the application.

## Changes
- Added conditional check for "quit" and "exit" commands that returns from the CLI loop
- Users can now exit the application by typing either "quit" or "exit" instead of using keyboard interrupts

## Implementation Details
The new commands are handled alongside existing commands like "new" in the main CLI loop. When either "quit" or "exit" is entered, the function returns cleanly, terminating the CLI session.

https://claude.ai/code/session_01LYkff5bwozour42GbbyLqc