### PR TITLE
Fix undo command matching to require exact match

### DIFF
--- a/src/hotaru/hotaru.py
+++ b/src/hotaru/hotaru.py
@@ -402,7 +402,7 @@ def cli(
             elif query[0] == "new":
                 state = State()
                 break
-            elif query[0] in ("undo"):
+            elif query[0] in ("undo",):
                 if state.previous is not None:
                     state = state.previous
                 else:


### PR DESCRIPTION
## Summary
- `query[0] in ("undo")` compared against the string `"undo"` instead of a one-element tuple, so any substring of "undo" (e.g. "d", "un", "do") was incorrectly treated as the undo command.
- Changed to `("undo",)` so only an exact match triggers undo, consistent with the `("quit", "exit")` check just below it.

## Test plan
- [x] `tox -e lint,type,format` passes
- [x] `tox -e 3.14` (pytest) passes: 26 passed, 2 skipped