### PR TITLE
Fix auto command not advancing state

### DIFF
--- a/src/hotaru/hotaru.py
+++ b/src/hotaru/hotaru.py
@@ -391,7 +391,7 @@ def cli(
                         if score == max(scores.values())
                     ]
                 )
-                state.move(move)
+                state = state.move(move)
                 break
             elif query[0] == "dice":
                 dice = int(query[1])

--- a/tests/test_hotaru.py
+++ b/tests/test_hotaru.py
@@ -502,6 +502,13 @@ def test_cli_7(run_cli: Callable[[list[str]], list[str]]) -> None:
     assert not any("Cannot undo" in output for output in outputs)
 
 
+def test_cli_8(run_cli: Callable[[list[str]], list[str]]) -> None:
+    outputs = run_cli(["dice 6", "auto", "quit"])
+    boards = [output for output in outputs if "Turn:" in output]
+    assert len(boards) == 3
+    assert boards[1] != boards[2]
+
+
 def test_autoplay_1(run_cli: Callable[[list[str]], list[str]]) -> None:
     wins = [0, 0, 0, 0]
     for _ in range(2000):


### PR DESCRIPTION
## Summary
- `state.move(move)` in the "auto" branch discarded its return value instead of reassigning it to `state`, so the "auto" command left the board unchanged.

## Test plan
- [x] Run the "auto" command and confirm the board state advances