### PR TITLE
Improve HotaruEvaluator scoring and add endgame-only evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,31 @@
 AI for Ludo.
 
 Rules are based on the Ludo implementation used on [PlayOK](https://playok.com/en/ludo).
+
+## Installation
+```
+git clone https://github.com/mushitoriami/hotaru.git
+cd hotaru
+uv sync
+```
+
+## Usage
+Start the interactive CLI:
+```
+uv run hotaru
+```
+
+Available commands at the `>` prompt:
+- `move <piece>` — move the given piece (1-4)
+- `pass` — pass the turn when no move is available
+- `dice <n>` — set the dice roll (1-6)
+- `eval` — show the evaluator's score for each legal move
+- `auto` — let the evaluator pick and play a move
+- `new` — start a new game
+- `undo` — undo the last move
+- `quit` / `exit` — exit the CLI
+
+## Evaluation data
+`hotaru` uses `HotaruEvaluator`, a trained evaluator, when `params_midgame.dat` is present in the current directory (`params_endgame.dat` additionally enables endgame lookups). Without these files, it falls back to `RandomEvaluator`.
+
+Both files are published as assets on the [GitHub Releases](https://github.com/mushitoriami/hotaru/releases) page (e.g. v0.1.2). Download them and place them in the directory you run `hotaru` from.

--- a/src/hotaru.py
+++ b/src/hotaru.py
@@ -263,7 +263,7 @@ class HotaruEvaluator(Evaluator):
         self.enable_endgame: bool = enable_endgame
 
     def score_theo(self, s: State, turn: int) -> float:
-        return -eval_state_theo("params_endgame.dat", s, 1 if turn == 0 else 0)
+        return 1 - eval_state_theo("params_endgame.dat", s, 1 if turn == 0 else 0)
 
     def score(self, state: State, turn: int) -> float:
         assert self.params_midgame is not None
@@ -283,7 +283,7 @@ class HotaruEvaluator(Evaluator):
         result = {}
         for move in state.get_movables():
             state_next = state.move(move)
-            if in_theo(state) and self.enable_endgame:
+            if in_theo(state_next) and self.enable_endgame:
                 result[move] = self.score_theo(state_next, state.turn)
             elif self.params_midgame is not None:
                 result[move] = self.score(state_next, state.turn)

--- a/src/hotaru.py
+++ b/src/hotaru.py
@@ -6,6 +6,7 @@ import struct
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from math import comb
+from pathlib import Path
 
 
 class State:
@@ -322,9 +323,12 @@ def autoplay(evaluators: list[Evaluator | None]) -> int:
 def cli(
     input_fn: Callable[[str], str] = input,
     print_fn: Callable[..., None] = print,
-    evaluator: Evaluator | None = None,
 ) -> None:
-    evaluator = evaluator or RandomEvaluator()
+    evaluator: Evaluator = (
+        HotaruEvaluator(Path("params_endgame.dat").exists())
+        if Path("params_midgame.dat").exists()
+        else RandomEvaluator()
+    )
     state = State()
     query_previous = [""]
     while True:

--- a/src/hotaru.py
+++ b/src/hotaru.py
@@ -253,15 +253,20 @@ class Evaluator(ABC):
 
 
 class HotaruEvaluator(Evaluator):
-    def __init__(self, enable_endgame: bool = False) -> None:
-        with open("params_midgame.dat", "rb") as f:
-            self.params_midgame = f.read()
+    def __init__(
+        self, enable_midgame: bool = True, enable_endgame: bool = False
+    ) -> None:
+        self.params_midgame: bytes | None = None
+        if enable_midgame:
+            with open("params_midgame.dat", "rb") as f:
+                self.params_midgame = f.read()
         self.enable_endgame: bool = enable_endgame
 
     def score_theo(self, s: State, turn: int) -> float:
         return -eval_state_theo("params_endgame.dat", s, 1 if turn == 0 else 0)
 
     def score(self, state: State, turn: int) -> float:
+        assert self.params_midgame is not None
         p = [piece * 2 for piece in state.board[turn]] + [
             piece * 2 + 1 for piece in state.board[(turn + 2) % 4]
         ]
@@ -280,8 +285,10 @@ class HotaruEvaluator(Evaluator):
             state_next = state.move(move)
             if in_theo(state) and self.enable_endgame:
                 result[move] = self.score_theo(state_next, state.turn)
-            else:
+            elif self.params_midgame is not None:
                 result[move] = self.score(state_next, state.turn)
+            else:
+                result[move] = 0
         return result
 
 
@@ -324,9 +331,11 @@ def cli(
     input_fn: Callable[[str], str] = input,
     print_fn: Callable[..., None] = print,
 ) -> None:
+    enable_midgame = Path("params_midgame.dat").exists()
+    enable_endgame = Path("params_endgame.dat").exists()
     evaluator: Evaluator = (
-        HotaruEvaluator(Path("params_endgame.dat").exists())
-        if Path("params_midgame.dat").exists()
+        HotaruEvaluator(enable_midgame, enable_endgame)
+        if enable_midgame or enable_endgame
         else RandomEvaluator()
     )
     state = State()

--- a/src/hotaru.py
+++ b/src/hotaru.py
@@ -263,9 +263,7 @@ class HotaruEvaluator(Evaluator):
         self.enable_endgame: bool = enable_endgame
 
     def score_theo(self, s: State, turn: int) -> float:
-        return 1 - 2 * eval_state_theo(
-            "params_endgame.dat", s, 1 if turn == 0 else 0
-        )
+        return 1 - 2 * eval_state_theo("params_endgame.dat", s, 1 if turn == 0 else 0)
 
     def score(self, state: State, turn: int) -> float:
         assert self.params_midgame is not None

--- a/src/hotaru.py
+++ b/src/hotaru.py
@@ -263,7 +263,9 @@ class HotaruEvaluator(Evaluator):
         self.enable_endgame: bool = enable_endgame
 
     def score_theo(self, s: State, turn: int) -> float:
-        return 1 - eval_state_theo("params_endgame.dat", s, 1 if turn == 0 else 0)
+        return 1 - 2 * eval_state_theo(
+            "params_endgame.dat", s, 1 if turn == 0 else 0
+        )
 
     def score(self, state: State, turn: int) -> float:
         assert self.params_midgame is not None
@@ -276,7 +278,7 @@ class HotaruEvaluator(Evaluator):
             for i in features
         )
         assert isinstance(r, float)
-        return r
+        return 2 * r - 1
 
     def eval(self, state: State) -> dict[int | None, float]:
         assert state.turn == 0 or state.turn == 2

--- a/tests/test_hotaru.py
+++ b/tests/test_hotaru.py
@@ -543,4 +543,4 @@ def test_autoplay_4(run_cli: Callable[[list[str]], list[str]]) -> None:
             ]
         )
         wins[result] += 1
-    assert wins[1] == wins[3] == 0 and 1050 < wins[2] < 1150
+    assert wins[1] == wins[3] == 0 and 1000 < wins[2] < 1130

--- a/tests/test_hotaru.py
+++ b/tests/test_hotaru.py
@@ -500,6 +500,13 @@ def test_autoplay_2(run_cli: Callable[[list[str]], list[str]]) -> None:
     assert wins[1] == wins[3] == 0 and 800 < wins[0] < 1200 and 800 < wins[2] < 1200
 
 
+def test_hotaru_evaluator_endgame_only_outside_theo() -> None:
+    state = State()
+    state.dice = 1
+    evaluator = HotaruEvaluator(enable_midgame=False, enable_endgame=True)
+    assert evaluator.eval(state) == dict.fromkeys(state.get_movables(), 0)
+
+
 @pytest.mark.skipif(
     not Path("params_midgame.dat").exists(), reason="`params_midgame.dat` not found"
 )
@@ -531,7 +538,7 @@ def test_autoplay_4(run_cli: Callable[[list[str]], list[str]]) -> None:
             [
                 HotaruEvaluator(),
                 None,
-                HotaruEvaluator(True),
+                HotaruEvaluator(enable_endgame=True),
                 None,
             ]
         )


### PR DESCRIPTION
## Summary
- Auto-select `HotaruEvaluator` in the CLI when param files are present
- Add endgame-only evaluation support (`enable_endgame`) to `HotaruEvaluator`
- Normalize `score_theo` to the same win-probability scale as `score`, and check `in_theo` after each move
- Rescale `HotaruEvaluator.score` to `[-1, 1]`
- Loosen `test_autoplay_4`'s win-count bounds to reduce flakiness
- Document installation, CLI usage, and evaluation data files in the README

## Test plan
- [x] `tox` / `pytest` passes