### PR TITLE
Refactor State into an immutable dataclass with seat selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Start the interactive CLI:
 uv run hotaru
 ```
 
+By default all four seats (0-3) participate. To play with fewer than four (minimum two), pass `--players` as a comma-separated list of seat indices:
+```
+uv run hotaru --players 0,2
+```
+
 Available commands at the `>` prompt:
 - `move <piece>` — move the given piece (1-4)
 - `pass` — pass the turn when no move is available

--- a/src/hotaru.py
+++ b/src/hotaru.py
@@ -10,21 +10,33 @@ from pathlib import Path
 
 
 class State:
-    def __init__(self, base: State | None = None) -> None:
+    def __init__(
+        self, base: State | None = None, players: frozenset[int] | None = None
+    ) -> None:
         if base is None:
+            self.players = frozenset(range(4)) if players is None else players
+            assert len(self.players) >= 2 and self.players <= frozenset(range(4))
             self.board = [list(range(4)) for _ in range(4)]
-            self.turn: int | None = 0
+            self.turn: int | None = min(self.players)
             self.winner: int | None = None
             self.dice = random.randint(1, 6)
             self.count_six, self.count_start = 0, 0
             self.previous: State | None = None
         else:
+            self.players = base.players
             self.board = [list(base.board[i]) for i in range(4)]
             self.turn = base.turn
             self.winner = base.winner
             self.dice = base.dice
             self.count_six, self.count_start = base.count_six, base.count_start
             self.previous = base
+
+    def next_turn(self, turn: int) -> int:
+        t = turn
+        while True:
+            t = (t + 1) % 4
+            if t in self.players:
+                return t
 
     def is_start(self) -> bool:
         return self.turn is not None and set(self.board[self.turn]) == {0, 1, 2, 3}
@@ -71,7 +83,7 @@ class State:
                 state.turn = None
             else:
                 if state.count_six == 0 and state.count_start == 0:
-                    state.turn = (state.turn + 1) % 4
+                    state.turn = state.next_turn(state.turn)
                 state.dice = random.randint(1, 6)
         return state
 

--- a/src/hotaru.py
+++ b/src/hotaru.py
@@ -14,7 +14,7 @@ from pathlib import Path
 @dataclass
 class State:
     players: frozenset[int]
-    board: list[list[int]]
+    board: tuple[tuple[int, ...], ...]
     turn: int | None
     winner: int | None
     dice: int
@@ -27,7 +27,7 @@ def new_state(players: frozenset[int] | None = None) -> State:
     assert len(players) >= 2 and players <= frozenset(range(4))
     return State(
         players=players,
-        board=[list(range(4)) for _ in range(4)],
+        board=tuple(tuple(range(4)) for _ in range(4)),
         turn=min(players),
         winner=None,
         dice=random.randint(1, 6),
@@ -39,7 +39,7 @@ def new_state(players: frozenset[int] | None = None) -> State:
 def copy_state(base: State) -> State:
     return State(
         players=base.players,
-        board=[list(base.board[i]) for i in range(4)],
+        board=base.board,
         turn=base.turn,
         winner=base.winner,
         dice=base.dice,
@@ -87,11 +87,13 @@ def apply_move(state: State, piece: int | None) -> State:
             if new.board[new.turn][piece - 1] >= 4
             else 4
         )
+        board = [list(row) for row in new.board]
         for t in range(4):
             for p in range(4):
-                if is_same_pos(move_to, new.turn, new.board[t][p], t):
-                    new.board[t][p] = p
-        new.board[new.turn][piece - 1] = move_to
+                if is_same_pos(move_to, new.turn, board[t][p], t):
+                    board[t][p] = p
+        board[new.turn][piece - 1] = move_to
+        new.board = tuple(tuple(row) for row in board)
     if piece is not None:
         new.count_six = (new.count_six + 1) % 3 if new.dice == 6 else 0
     else:
@@ -250,7 +252,7 @@ def read_bin(filename: str, index: int) -> float:
         return r
 
 
-def rank_pieces(positions: list[int]) -> tuple[int, int, int]:
+def rank_pieces(positions: tuple[int, ...]) -> tuple[int, int, int]:
     d = sorted(positions, reverse=True)
     assert d[0] == 47
     for i, floor in ((3, 0), (2, 1), (1, 2)):

--- a/src/hotaru.py
+++ b/src/hotaru.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import random
 import readline  # noqa: F401
 import struct
@@ -339,10 +340,31 @@ def autoplay(evaluators: list[Evaluator | None]) -> int:
     return state.winner
 
 
+def parse_players(value: str) -> frozenset[int]:
+    try:
+        players = frozenset(int(seat) for seat in value.split(","))
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"invalid players: {value}") from None
+    if not (players <= frozenset(range(4)) and len(players) >= 2):
+        raise argparse.ArgumentTypeError(f"invalid players: {value}")
+    return players
+
+
 def cli(
+    argv: list[str] | None = None,
     input_fn: Callable[[str], str] = input,
     print_fn: Callable[..., None] = print,
 ) -> None:
+    parser = argparse.ArgumentParser(prog="hotaru")
+    parser.add_argument(
+        "--players",
+        type=parse_players,
+        default=frozenset(range(4)),
+        help="comma-separated seat indices (0-3, at least 2) that participate,"
+        " e.g. 0,2 (default: 0,1,2,3)",
+    )
+    args = parser.parse_args(argv)
+
     enable_midgame = Path("params_midgame.dat").exists()
     enable_endgame = Path("params_endgame.dat").exists()
     evaluator: Evaluator = (
@@ -350,7 +372,7 @@ def cli(
         if enable_midgame or enable_endgame
         else RandomEvaluator()
     )
-    state = State()
+    state = State(players=args.players)
     query_previous = [""]
     while True:
         movables = state.get_movables()
@@ -403,7 +425,7 @@ def cli(
                     break
                 print_fn("Invalid dice roll: " + query[1])
             elif query[0] == "new":
-                state = State()
+                state = State(players=args.players)
                 break
             elif query[0] in ("undo",):
                 if state.previous is not None:

--- a/src/hotaru.py
+++ b/src/hotaru.py
@@ -6,7 +6,7 @@ import readline  # noqa: F401
 import struct
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from math import comb
 from pathlib import Path
 
@@ -33,18 +33,6 @@ def new_state(players: frozenset[int] | None = None) -> State:
         dice=random.randint(1, 6),
         count_six=0,
         count_start=0,
-    )
-
-
-def copy_state(base: State) -> State:
-    return State(
-        players=base.players,
-        board=base.board,
-        turn=base.turn,
-        winner=base.winner,
-        dice=base.dice,
-        count_six=base.count_six,
-        count_start=base.count_start,
     )
 
 
@@ -80,7 +68,7 @@ def get_movables(state: State) -> list[int | None]:
 
 
 def apply_move(state: State, piece: int | None) -> State:
-    new = copy_state(state)
+    new = replace(state)
     if new.turn is not None and piece is not None:
         move_to = (
             new.board[new.turn][piece - 1] + new.dice

--- a/src/hotaru.py
+++ b/src/hotaru.py
@@ -20,7 +20,6 @@ class State:
     dice: int
     count_six: int
     count_start: int
-    previous: State | None = None
 
 
 def new_state(players: frozenset[int] | None = None) -> State:
@@ -34,7 +33,6 @@ def new_state(players: frozenset[int] | None = None) -> State:
         dice=random.randint(1, 6),
         count_six=0,
         count_start=0,
-        previous=None,
     )
 
 
@@ -47,7 +45,6 @@ def copy_state(base: State) -> State:
         dice=base.dice,
         count_six=base.count_six,
         count_start=base.count_start,
-        previous=base,
     )
 
 
@@ -394,6 +391,7 @@ def cli(
         else RandomEvaluator()
     )
     state = new_state(players=args.players)
+    history: list[State] = []
     query_previous = [""]
     while True:
         movables = get_movables(state)
@@ -407,11 +405,13 @@ def cli(
             if query[0] == "move":
                 piece = int(query[1])
                 if piece in movables:
+                    history.append(state)
                     state = apply_move(state, piece)
                     break
                 print_fn("Cannot move: " + query[1])
             elif query[0] == "pass":
                 if None in movables:
+                    history.append(state)
                     state = apply_move(state, None)
                     break
                 print_fn("Cannot pass")
@@ -437,6 +437,7 @@ def cli(
                         if score == max(scores.values())
                     ]
                 )
+                history.append(state)
                 state = apply_move(state, move)
                 break
             elif query[0] == "dice":
@@ -447,10 +448,11 @@ def cli(
                 print_fn("Invalid dice roll: " + query[1])
             elif query[0] == "new":
                 state = new_state(players=args.players)
+                history = []
                 break
             elif query[0] in ("undo",):
-                if state.previous is not None:
-                    state = state.previous
+                if history:
+                    state = history.pop()
                 else:
                     print_fn("Cannot undo")
                 break

--- a/src/hotaru.py
+++ b/src/hotaru.py
@@ -6,204 +6,225 @@ import readline  # noqa: F401
 import struct
 from abc import ABC, abstractmethod
 from collections.abc import Callable
+from dataclasses import dataclass
 from math import comb
 from pathlib import Path
 
 
+@dataclass
 class State:
-    def __init__(
-        self, base: State | None = None, players: frozenset[int] | None = None
-    ) -> None:
-        if base is None:
-            self.players = frozenset(range(4)) if players is None else players
-            assert len(self.players) >= 2 and self.players <= frozenset(range(4))
-            self.board = [list(range(4)) for _ in range(4)]
-            self.turn: int | None = min(self.players)
-            self.winner: int | None = None
-            self.dice = random.randint(1, 6)
-            self.count_six, self.count_start = 0, 0
-            self.previous: State | None = None
+    players: frozenset[int]
+    board: list[list[int]]
+    turn: int | None
+    winner: int | None
+    dice: int
+    count_six: int
+    count_start: int
+    previous: State | None = None
+
+
+def new_state(players: frozenset[int] | None = None) -> State:
+    players = frozenset(range(4)) if players is None else players
+    assert len(players) >= 2 and players <= frozenset(range(4))
+    return State(
+        players=players,
+        board=[list(range(4)) for _ in range(4)],
+        turn=min(players),
+        winner=None,
+        dice=random.randint(1, 6),
+        count_six=0,
+        count_start=0,
+        previous=None,
+    )
+
+
+def copy_state(base: State) -> State:
+    return State(
+        players=base.players,
+        board=[list(base.board[i]) for i in range(4)],
+        turn=base.turn,
+        winner=base.winner,
+        dice=base.dice,
+        count_six=base.count_six,
+        count_start=base.count_start,
+        previous=base,
+    )
+
+
+def next_turn(state: State, turn: int) -> int:
+    t = turn
+    while True:
+        t = (t + 1) % 4
+        if t in state.players:
+            return t
+
+
+def is_start(state: State) -> bool:
+    return state.turn is not None and set(state.board[state.turn]) == {0, 1, 2, 3}
+
+
+def get_movables(state: State) -> list[int | None]:
+    if state.turn is None:
+        return []
+    moves: list[int | None] = []
+    for i in range(4):
+        move_from = state.board[state.turn][i]
+        if move_from >= 4:
+            move_to = move_from + state.dice
+        elif state.dice == 6:
+            move_to = 4
         else:
-            self.players = base.players
-            self.board = [list(base.board[i]) for i in range(4)]
-            self.turn = base.turn
-            self.winner = base.winner
-            self.dice = base.dice
-            self.count_six, self.count_start = base.count_six, base.count_start
-            self.previous = base
+            continue
+        if move_to <= 47 and move_to not in state.board[state.turn]:
+            moves.append(i + 1)
+    if len(moves) == 0:
+        moves.append(None)
+    return moves
 
-    def next_turn(self, turn: int) -> int:
-        t = turn
-        while True:
-            t = (t + 1) % 4
-            if t in self.players:
-                return t
 
-    def is_start(self) -> bool:
-        return self.turn is not None and set(self.board[self.turn]) == {0, 1, 2, 3}
-
-    def get_movables(self) -> list[int | None]:
-        if self.turn is None:
-            return []
-        moves: list[int | None] = []
-        for i in range(4):
-            move_from = self.board[self.turn][i]
-            if move_from >= 4:
-                move_to = move_from + self.dice
-            elif self.dice == 6:
-                move_to = 4
-            else:
-                continue
-            if move_to <= 47 and move_to not in self.board[self.turn]:
-                moves.append(i + 1)
-        if len(moves) == 0:
-            moves.append(None)
-        return moves
-
-    def move(self, piece: int | None) -> State:
-        state = State(self)
-        if state.turn is not None and piece is not None:
-            move_to = (
-                state.board[state.turn][piece - 1] + state.dice
-                if state.board[state.turn][piece - 1] >= 4
-                else 4
-            )
-            for t in range(4):
-                for p in range(4):
-                    if is_same_pos(move_to, state.turn, state.board[t][p], t):
-                        state.board[t][p] = p
-            state.board[state.turn][piece - 1] = move_to
-        if piece is not None:
-            state.count_six = (state.count_six + 1) % 3 if state.dice == 6 else 0
-        else:
-            state.count_six = 0
-        state.count_start = (state.count_start + 1) % 3 if state.is_start() else 0
-        if state.turn is not None:
-            if set(state.board[state.turn]) == {44, 45, 46, 47}:
-                state.winner = state.turn
-                state.turn = None
-            else:
-                if state.count_six == 0 and state.count_start == 0:
-                    state.turn = state.next_turn(state.turn)
-                state.dice = random.randint(1, 6)
-        return state
-
-    def visualize(self, colored: bool = True) -> str:
-        color_bg = ["\033[97;41m", "\033[97;42m", "\033[97;44m", "\033[30;43m"]
-        color_reset = "\033[0m"
-
-        table: list[list[None | str]] = [
-            [None, None, None, None, "  ", "  ", "  ", None, None, None, None],
-            [None, "  ", "  ", None, "  ", "  ", "  ", None, "  ", "  ", None],
-            [None, "  ", "  ", None, "  ", "  ", "  ", None, "  ", "  ", None],
-            [None, None, None, None, "  ", "  ", "  ", None, None, None, None],
-            ["  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  "],
-            ["  ", "  ", "  ", "  ", "  ", None, "  ", "  ", "  ", "  ", "  "],
-            ["  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  "],
-            [None, None, None, None, "  ", "  ", "  ", None, None, None, None],
-            [None, "  ", "  ", None, "  ", "  ", "  ", None, "  ", "  ", None],
-            [None, "  ", "  ", None, "  ", "  ", "  ", None, "  ", "  ", None],
-            [None, None, None, None, "  ", "  ", "  ", None, None, None, None],
-        ]
-        mapping_r = [
-            (10, 4),
-            (9, 4),
-            (8, 4),
-            (7, 4),
-            (6, 4),
-            (6, 3),
-            (6, 2),
-            (6, 1),
-            (6, 0),
-            (5, 0),
-        ]
-        mapping_g = [
-            (4, 0),
-            (4, 1),
-            (4, 2),
-            (4, 3),
-            (4, 4),
-            (3, 4),
-            (2, 4),
-            (1, 4),
-            (0, 4),
-            (0, 5),
-        ]
-        mapping_b = [
-            (0, 6),
-            (1, 6),
-            (2, 6),
-            (3, 6),
-            (4, 6),
-            (4, 7),
-            (4, 8),
-            (4, 9),
-            (4, 10),
-            (5, 10),
-        ]
-        mapping_y = [
-            (6, 10),
-            (6, 9),
-            (6, 8),
-            (6, 7),
-            (6, 6),
-            (7, 6),
-            (8, 6),
-            (9, 6),
-            (10, 6),
-            (10, 5),
-        ]
-        mapping = [
-            (
-                [(8, 1), (8, 2), (9, 1), (9, 2)]
-                + (mapping_r + mapping_g + mapping_b + mapping_y)
-                + [(9, 5), (8, 5), (7, 5), (6, 5)]
-            ),
-            (
-                [(1, 1), (1, 2), (2, 1), (2, 2)]
-                + (mapping_g + mapping_b + mapping_y + mapping_r)
-                + [(5, 1), (5, 2), (5, 3), (5, 4)]
-            ),
-            (
-                [(1, 8), (1, 9), (2, 8), (2, 9)]
-                + (mapping_b + mapping_y + mapping_r + mapping_g)
-                + [(1, 5), (2, 5), (3, 5), (4, 5)]
-            ),
-            (
-                [(8, 8), (8, 9), (9, 8), (9, 9)]
-                + (mapping_y + mapping_r + mapping_g + mapping_b)
-                + [(5, 9), (5, 8), (5, 7), (5, 6)]
-            ),
-        ]
-        mapping_color = ["R", "G", "B", "Y"]
+def apply_move(state: State, piece: int | None) -> State:
+    new = copy_state(state)
+    if new.turn is not None and piece is not None:
+        move_to = (
+            new.board[new.turn][piece - 1] + new.dice
+            if new.board[new.turn][piece - 1] >= 4
+            else 4
+        )
         for t in range(4):
             for p in range(4):
-                x, y = mapping[t][self.board[t][p]]
-                if colored:
-                    table[x][y] = (
-                        color_bg[t] + mapping_color[t] + color_reset + str(p + 1)
-                    )
-                else:
-                    table[x][y] = mapping_color[t] + str(p + 1)
-        visualized = ""
-        for x in range(11):
-            for c in table[x]:
-                visualized += "[" + c + "]" if c is not None else "    "
-            visualized += "\n"
-        visualized += "\n"
-        if self.turn is not None:
-            turn_label = mapping_color[self.turn]
-            if colored:
-                turn_label = color_bg[self.turn] + turn_label + color_reset
-            visualized += "Turn: " + turn_label + ", Dice: " + str(self.dice)
-        elif self.winner is not None:
-            winner_label = mapping_color[self.winner]
-            if colored:
-                winner_label = color_bg[self.winner] + winner_label + color_reset
-            visualized += "Winner: " + winner_label
+                if is_same_pos(move_to, new.turn, new.board[t][p], t):
+                    new.board[t][p] = p
+        new.board[new.turn][piece - 1] = move_to
+    if piece is not None:
+        new.count_six = (new.count_six + 1) % 3 if new.dice == 6 else 0
+    else:
+        new.count_six = 0
+    new.count_start = (new.count_start + 1) % 3 if is_start(new) else 0
+    if new.turn is not None:
+        if set(new.board[new.turn]) == {44, 45, 46, 47}:
+            new.winner = new.turn
+            new.turn = None
         else:
-            assert False, "unreachable"
-        return visualized
+            if new.count_six == 0 and new.count_start == 0:
+                new.turn = next_turn(new, new.turn)
+            new.dice = random.randint(1, 6)
+    return new
+
+
+def visualize(state: State, colored: bool = True) -> str:
+    color_bg = ["\033[97;41m", "\033[97;42m", "\033[97;44m", "\033[30;43m"]
+    color_reset = "\033[0m"
+
+    table: list[list[None | str]] = [
+        [None, None, None, None, "  ", "  ", "  ", None, None, None, None],
+        [None, "  ", "  ", None, "  ", "  ", "  ", None, "  ", "  ", None],
+        [None, "  ", "  ", None, "  ", "  ", "  ", None, "  ", "  ", None],
+        [None, None, None, None, "  ", "  ", "  ", None, None, None, None],
+        ["  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  "],
+        ["  ", "  ", "  ", "  ", "  ", None, "  ", "  ", "  ", "  ", "  "],
+        ["  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  "],
+        [None, None, None, None, "  ", "  ", "  ", None, None, None, None],
+        [None, "  ", "  ", None, "  ", "  ", "  ", None, "  ", "  ", None],
+        [None, "  ", "  ", None, "  ", "  ", "  ", None, "  ", "  ", None],
+        [None, None, None, None, "  ", "  ", "  ", None, None, None, None],
+    ]
+    mapping_r = [
+        (10, 4),
+        (9, 4),
+        (8, 4),
+        (7, 4),
+        (6, 4),
+        (6, 3),
+        (6, 2),
+        (6, 1),
+        (6, 0),
+        (5, 0),
+    ]
+    mapping_g = [
+        (4, 0),
+        (4, 1),
+        (4, 2),
+        (4, 3),
+        (4, 4),
+        (3, 4),
+        (2, 4),
+        (1, 4),
+        (0, 4),
+        (0, 5),
+    ]
+    mapping_b = [
+        (0, 6),
+        (1, 6),
+        (2, 6),
+        (3, 6),
+        (4, 6),
+        (4, 7),
+        (4, 8),
+        (4, 9),
+        (4, 10),
+        (5, 10),
+    ]
+    mapping_y = [
+        (6, 10),
+        (6, 9),
+        (6, 8),
+        (6, 7),
+        (6, 6),
+        (7, 6),
+        (8, 6),
+        (9, 6),
+        (10, 6),
+        (10, 5),
+    ]
+    mapping = [
+        (
+            [(8, 1), (8, 2), (9, 1), (9, 2)]
+            + (mapping_r + mapping_g + mapping_b + mapping_y)
+            + [(9, 5), (8, 5), (7, 5), (6, 5)]
+        ),
+        (
+            [(1, 1), (1, 2), (2, 1), (2, 2)]
+            + (mapping_g + mapping_b + mapping_y + mapping_r)
+            + [(5, 1), (5, 2), (5, 3), (5, 4)]
+        ),
+        (
+            [(1, 8), (1, 9), (2, 8), (2, 9)]
+            + (mapping_b + mapping_y + mapping_r + mapping_g)
+            + [(1, 5), (2, 5), (3, 5), (4, 5)]
+        ),
+        (
+            [(8, 8), (8, 9), (9, 8), (9, 9)]
+            + (mapping_y + mapping_r + mapping_g + mapping_b)
+            + [(5, 9), (5, 8), (5, 7), (5, 6)]
+        ),
+    ]
+    mapping_color = ["R", "G", "B", "Y"]
+    for t in range(4):
+        for p in range(4):
+            x, y = mapping[t][state.board[t][p]]
+            if colored:
+                table[x][y] = color_bg[t] + mapping_color[t] + color_reset + str(p + 1)
+            else:
+                table[x][y] = mapping_color[t] + str(p + 1)
+    visualized = ""
+    for x in range(11):
+        for c in table[x]:
+            visualized += "[" + c + "]" if c is not None else "    "
+        visualized += "\n"
+    visualized += "\n"
+    if state.turn is not None:
+        turn_label = mapping_color[state.turn]
+        if colored:
+            turn_label = color_bg[state.turn] + turn_label + color_reset
+        visualized += "Turn: " + turn_label + ", Dice: " + str(state.dice)
+    elif state.winner is not None:
+        winner_label = mapping_color[state.winner]
+        if colored:
+            winner_label = color_bg[state.winner] + winner_label + color_reset
+        visualized += "Winner: " + winner_label
+    else:
+        assert False, "unreachable"
+    return visualized
 
 
 def in_theo(s: State) -> bool:
@@ -294,8 +315,8 @@ class HotaruEvaluator(Evaluator):
     def eval(self, state: State) -> dict[int | None, float]:
         assert state.turn == 0 or state.turn == 2
         result = {}
-        for move in state.get_movables():
-            state_next = state.move(move)
+        for move in get_movables(state):
+            state_next = apply_move(state, move)
             if in_theo(state_next) and self.enable_endgame:
                 result[move] = self.score_theo(state_next, state.turn)
             elif self.params_midgame is not None:
@@ -307,7 +328,7 @@ class HotaruEvaluator(Evaluator):
 
 class RandomEvaluator(Evaluator):
     def eval(self, state: State) -> dict[int | None, float]:
-        return dict.fromkeys(state.get_movables(), 0)
+        return dict.fromkeys(get_movables(state), 0)
 
 
 def get_absolute_pos(pos: int, turn: int) -> int:
@@ -321,11 +342,11 @@ def is_same_pos(pos1: int, turn1: int, pos2: int, turn2: int) -> bool:
 
 
 def autoplay(evaluators: list[Evaluator | None]) -> int:
-    state = State()
+    state = new_state()
     while state.turn is not None:
         evaluator = evaluators[state.turn]
         if evaluator is None:
-            state = state.move(None)
+            state = apply_move(state, None)
         else:
             scores = evaluator.eval(state)
             move = random.choice(
@@ -335,7 +356,7 @@ def autoplay(evaluators: list[Evaluator | None]) -> int:
                     if score == max(scores.values())
                 ]
             )
-            state = state.move(move)
+            state = apply_move(state, move)
     assert state.winner is not None
     return state.winner
 
@@ -372,11 +393,11 @@ def cli(
         if enable_midgame or enable_endgame
         else RandomEvaluator()
     )
-    state = State(players=args.players)
+    state = new_state(players=args.players)
     query_previous = [""]
     while True:
-        movables = state.get_movables()
-        print_fn(state.visualize())
+        movables = get_movables(state)
+        print_fn(visualize(state))
         while True:
             query = input_fn("> ").split()
             if len(query) == 0:
@@ -386,12 +407,12 @@ def cli(
             if query[0] == "move":
                 piece = int(query[1])
                 if piece in movables:
-                    state = state.move(piece)
+                    state = apply_move(state, piece)
                     break
                 print_fn("Cannot move: " + query[1])
             elif query[0] == "pass":
                 if None in movables:
-                    state = state.move(None)
+                    state = apply_move(state, None)
                     break
                 print_fn("Cannot pass")
             elif query[0] == "eval":
@@ -416,7 +437,7 @@ def cli(
                         if score == max(scores.values())
                     ]
                 )
-                state = state.move(move)
+                state = apply_move(state, move)
                 break
             elif query[0] == "dice":
                 dice = int(query[1])
@@ -425,7 +446,7 @@ def cli(
                     break
                 print_fn("Invalid dice roll: " + query[1])
             elif query[0] == "new":
-                state = State(players=args.players)
+                state = new_state(players=args.players)
                 break
             elif query[0] in ("undo",):
                 if state.previous is not None:

--- a/tests/test_hotaru.py
+++ b/tests/test_hotaru.py
@@ -409,8 +409,8 @@ def test_count_six_reset_on_pass() -> None:
 
 
 @pytest.fixture
-def run_cli() -> Callable[[list[str]], list[str]]:
-    def _run(inputs: list[str]) -> list[str]:
+def run_cli() -> Callable[..., list[str]]:
+    def _run(inputs: list[str], argv: list[str] | None = None) -> list[str]:
         input_iter = iter(inputs)
         outputs: list[str] = []
 
@@ -420,7 +420,11 @@ def run_cli() -> Callable[[list[str]], list[str]]:
         def mock_print(*args: object) -> None:
             outputs.append(" ".join(str(arg) for arg in args))
 
-        cli(input_fn=mock_input, print_fn=mock_print)
+        cli(
+            argv=argv if argv is not None else [],
+            input_fn=mock_input,
+            print_fn=mock_print,
+        )
         return outputs
 
     return _run
@@ -468,6 +472,17 @@ def test_cli_8(run_cli: Callable[[list[str]], list[str]]) -> None:
     boards = [output for output in outputs if "Turn:" in output]
     assert len(boards) == 3
     assert boards[1] != boards[2]
+
+
+def test_cli_players_option(run_cli: Callable[..., list[str]]) -> None:
+    green_bg, reset = "\033[97;42m", "\033[0m"
+    outputs = run_cli(["quit"], argv=["--players", "1,3"])
+    assert any(f"Turn: {green_bg}G{reset}" in output for output in outputs)
+
+
+def test_cli_players_option_invalid(run_cli: Callable[..., list[str]]) -> None:
+    with pytest.raises(SystemExit):
+        run_cli(["quit"], argv=["--players", "0"])
 
 
 def test_autoplay_1(run_cli: Callable[[list[str]], list[str]]) -> None:

--- a/tests/test_hotaru.py
+++ b/tests/test_hotaru.py
@@ -6,24 +6,28 @@ import pytest
 from hotaru import (
     HotaruEvaluator,
     RandomEvaluator,
-    State,
+    apply_move,
     autoplay,
     cli,
     get_absolute_pos,
+    get_movables,
     is_same_pos,
+    is_start,
+    new_state,
+    visualize,
 )
 
 
 def test_init_board() -> None:
-    assert State().board == [[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
+    assert new_state().board == [[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
 
 
 def test_board_0() -> None:
-    state = State()
+    state = new_state()
     state.dice = 1
-    assert state.is_start() is True
+    assert is_start(state) is True
     assert (
-        state.visualize(colored=False)
+        visualize(state, colored=False)
         == "                [  ][  ][  ]                \n"
         + "    [G1][G2]    [  ][  ][  ]    [B1][B2]    \n"
         + "    [G3][G4]    [  ][  ][  ]    [B3][B4]    \n"
@@ -42,11 +46,11 @@ def test_board_0() -> None:
 
 
 def test_board_1() -> None:
-    state = State()
+    state = new_state()
     state.board = [[46, 1, 8, 10], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
     state.dice, state.turn = 2, 0
-    assert state.get_movables() == [4]
-    state = state.move(4)
+    assert get_movables(state) == [4]
+    state = apply_move(state, 4)
     assert state.board == [
         [46, 1, 8, 12],
         [0, 1, 2, 3],
@@ -54,9 +58,9 @@ def test_board_1() -> None:
         [0, 1, 2, 3],
     ]
     state.dice = 5
-    assert state.is_start() is True
+    assert is_start(state) is True
     assert (
-        state.visualize(colored=False)
+        visualize(state, colored=False)
         == "                [  ][  ][  ]                \n"
         + "    [G1][G2]    [  ][  ][  ]    [B1][B2]    \n"
         + "    [G3][G4]    [  ][  ][  ]    [B3][B4]    \n"
@@ -75,11 +79,11 @@ def test_board_1() -> None:
 
 
 def test_board_2() -> None:
-    state = State()
+    state = new_state()
     state.board = [[10, 4, 2, 43], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
     state.dice, state.turn = 6, 0
-    assert state.get_movables() == [1]
-    state = state.move(1)
+    assert get_movables(state) == [1]
+    state = apply_move(state, 1)
     assert state.board == [
         [16, 4, 2, 43],
         [0, 1, 2, 3],
@@ -87,9 +91,9 @@ def test_board_2() -> None:
         [0, 1, 2, 3],
     ]
     state.dice = 5
-    assert state.is_start() is False
+    assert is_start(state) is False
     assert (
-        state.visualize(colored=False)
+        visualize(state, colored=False)
         == "                [  ][  ][  ]                \n"
         + "    [G1][G2]    [  ][  ][  ]    [B1][B2]    \n"
         + "    [G3][G4]    [  ][  ][  ]    [B3][B4]    \n"
@@ -108,11 +112,11 @@ def test_board_2() -> None:
 
 
 def test_board_3() -> None:
-    state = State()
+    state = new_state()
     state.board = [[0, 7, 46, 15], [0, 34, 2, 3], [0, 1, 2, 3], [0, 1, 2, 19]]
     state.dice, state.turn = 2, 0
-    assert state.get_movables() == [2, 4]
-    state = state.move(2)
+    assert get_movables(state) == [2, 4]
+    state = apply_move(state, 2)
     assert state.board == [
         [0, 9, 46, 15],
         [0, 34, 2, 3],
@@ -120,9 +124,9 @@ def test_board_3() -> None:
         [0, 1, 2, 3],
     ]
     state.dice = 5
-    assert state.is_start() is False
+    assert is_start(state) is False
     assert (
-        state.visualize(colored=False)
+        visualize(state, colored=False)
         == "                [  ][  ][  ]                \n"
         + "    [G1][  ]    [  ][  ][  ]    [B1][B2]    \n"
         + "    [G3][G4]    [  ][  ][  ]    [B3][B4]    \n"
@@ -141,11 +145,11 @@ def test_board_3() -> None:
 
 
 def test_board_4() -> None:
-    state = State()
+    state = new_state()
     state.board = [[13, 43, 2, 3], [0, 1, 34, 3], [0, 1, 2, 3], [0, 29, 2, 3]]
     state.dice, state.turn = 6, 0
-    assert state.get_movables() == [1, 3, 4]
-    state = state.move(3)
+    assert get_movables(state) == [1, 3, 4]
+    state = apply_move(state, 3)
     assert state.board == [
         [13, 43, 4, 3],
         [0, 1, 2, 3],
@@ -153,9 +157,9 @@ def test_board_4() -> None:
         [0, 29, 2, 3],
     ]
     state.dice = 3
-    assert state.is_start() is False
+    assert is_start(state) is False
     assert (
-        state.visualize(colored=False)
+        visualize(state, colored=False)
         == "                [  ][  ][  ]                \n"
         + "    [G1][G2]    [  ][  ][  ]    [B1][B2]    \n"
         + "    [G3][G4]    [  ][  ][  ]    [B3][B4]    \n"
@@ -174,11 +178,11 @@ def test_board_4() -> None:
 
 
 def test_board_5() -> None:
-    state = State()
+    state = new_state()
     state.board = [[0, 29, 2, 3], [13, 43, 2, 3], [0, 1, 34, 3], [0, 1, 2, 3]]
     state.dice, state.turn = 6, 1
-    assert state.get_movables() == [1, 3, 4]
-    state = state.move(4)
+    assert get_movables(state) == [1, 3, 4]
+    state = apply_move(state, 4)
     assert state.board == [
         [0, 29, 2, 3],
         [13, 43, 2, 4],
@@ -186,9 +190,9 @@ def test_board_5() -> None:
         [0, 1, 2, 3],
     ]
     state.dice = 4
-    assert state.is_start() is False
+    assert is_start(state) is False
     assert (
-        state.visualize(colored=False)
+        visualize(state, colored=False)
         == "                [  ][G1][  ]                \n"
         + "    [  ][  ]    [  ][  ][  ]    [B1][B2]    \n"
         + "    [G3][  ]    [  ][  ][  ]    [B3][B4]    \n"
@@ -245,7 +249,7 @@ def test_is_same_pos() -> None:
 
 
 def test_visualize_colored() -> None:
-    state = State()
+    state = new_state()
     state.dice = 1
 
     red_bg = "\033[97;41m"
@@ -254,7 +258,7 @@ def test_visualize_colored() -> None:
     yellow_bg = "\033[30;43m"
     reset = "\033[0m"
 
-    colored_output = state.visualize(colored=True)
+    colored_output = visualize(state, colored=True)
 
     assert f"[{red_bg}R{reset}1]" in colored_output
     assert f"[{green_bg}G{reset}1]" in colored_output
@@ -265,7 +269,7 @@ def test_visualize_colored() -> None:
 
 
 def test_visualize_colored_winner() -> None:
-    state = State()
+    state = new_state()
     state.board = [[44, 45, 46, 47], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
     state.turn = None
     state.winner = 0
@@ -273,136 +277,136 @@ def test_visualize_colored_winner() -> None:
     red_bg = "\033[97;41m"
     reset = "\033[0m"
 
-    colored_output = state.visualize(colored=True)
+    colored_output = visualize(state, colored=True)
     assert f"Winner: {red_bg}R{reset}" in colored_output
 
 
 def test_three_sixes_rule() -> None:
-    state = State()
+    state = new_state()
     state.board = [[4, 5, 6, 7], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
     state.turn = 0
     state.count_six = 0
 
     state.dice = 6
-    state = state.move(1)
+    state = apply_move(state, 1)
     assert state.count_six == 1
     assert state.turn == 0
 
     state.dice = 6
-    state = state.move(1)
+    state = apply_move(state, 1)
     assert state.count_six == 2
     assert state.turn == 0
 
     state.dice = 6
-    state = state.move(1)
+    state = apply_move(state, 1)
     assert state.count_six == 0
     assert state.turn == 1
 
 
 def test_three_sixes_rule_reset_on_non_six() -> None:
-    state = State()
+    state = new_state()
     state.board = [[4, 5, 6, 7], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
     state.turn = 0
     state.count_six = 0
 
     state.dice = 6
-    state = state.move(1)
+    state = apply_move(state, 1)
     assert state.count_six == 1
     assert state.turn == 0
 
     state.dice = 6
-    state = state.move(1)
+    state = apply_move(state, 1)
     assert state.count_six == 2
     assert state.turn == 0
 
     state.dice = 3
-    state = state.move(1)
+    state = apply_move(state, 1)
     assert state.count_six == 0
     assert state.turn == 1
 
 
 def test_three_starts_rule() -> None:
-    state = State()
+    state = new_state()
     state.board = [[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
     state.turn = 0
     state.count_start = 0
 
     state.dice = 3
-    assert state.get_movables() == [None]
-    state = state.move(None)
+    assert get_movables(state) == [None]
+    state = apply_move(state, None)
     assert state.count_start == 1
     assert state.turn == 0
 
     state.dice = 2
-    state = state.move(None)
+    state = apply_move(state, None)
     assert state.count_start == 2
     assert state.turn == 0
 
     state.dice = 4
-    state = state.move(None)
+    state = apply_move(state, None)
     assert state.count_start == 0
     assert state.turn == 1
 
 
 def test_three_starts_rule_reset_on_leaving_start() -> None:
-    state = State()
+    state = new_state()
     state.board = [[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
     state.turn = 0
     state.count_start = 0
 
     state.dice = 3
-    state = state.move(None)
+    state = apply_move(state, None)
     assert state.count_start == 1
     assert state.turn == 0
 
     state.dice = 2
-    state = state.move(None)
+    state = apply_move(state, None)
     assert state.count_start == 2
     assert state.turn == 0
 
     state.dice = 6
-    state = state.move(1)
+    state = apply_move(state, 1)
     assert state.board[0][0] == 4
-    assert state.is_start() is False
+    assert is_start(state) is False
     assert state.count_start == 0
     assert state.count_six == 1
     assert state.turn == 0
 
 
 def test_three_starts_with_six_interaction() -> None:
-    state = State()
+    state = new_state()
     state.board = [[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
     state.turn = 0
     state.count_start = 2
     state.count_six = 0
 
     state.dice = 6
-    state = state.move(1)
-    assert state.is_start() is False
+    state = apply_move(state, 1)
+    assert is_start(state) is False
     assert state.count_start == 0
     assert state.count_six == 1
     assert state.turn == 0
 
     state.dice = 6
-    state = state.move(1)
+    state = apply_move(state, 1)
     assert state.count_six == 2
     assert state.turn == 0
 
     state.dice = 6
-    state = state.move(1)
+    state = apply_move(state, 1)
     assert state.count_six == 0
     assert state.turn == 1
 
 
 def test_count_six_reset_on_pass() -> None:
-    state = State()
+    state = new_state()
     state.board = [[43, 45, 46, 47], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
     state.turn = 0
     state.count_six = 1
 
     state.dice = 6
-    assert state.get_movables() == [None]
-    state = state.move(None)
+    assert get_movables(state) == [None]
+    state = apply_move(state, None)
 
     assert state.count_six == 0
     assert state.turn == 1
@@ -516,10 +520,10 @@ def test_autoplay_2(run_cli: Callable[[list[str]], list[str]]) -> None:
 
 
 def test_hotaru_evaluator_endgame_only_outside_theo() -> None:
-    state = State()
+    state = new_state()
     state.dice = 1
     evaluator = HotaruEvaluator(enable_midgame=False, enable_endgame=True)
-    assert evaluator.eval(state) == dict.fromkeys(state.get_movables(), 0)
+    assert evaluator.eval(state) == dict.fromkeys(get_movables(state), 0)
 
 
 @pytest.mark.skipif(

--- a/tests/test_hotaru.py
+++ b/tests/test_hotaru.py
@@ -19,7 +19,7 @@ from hotaru import (
 
 
 def test_init_board() -> None:
-    assert new_state().board == [[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
+    assert new_state().board == ((0, 1, 2, 3), (0, 1, 2, 3), (0, 1, 2, 3), (0, 1, 2, 3))
 
 
 def test_board_0() -> None:
@@ -47,16 +47,11 @@ def test_board_0() -> None:
 
 def test_board_1() -> None:
     state = new_state()
-    state.board = [[46, 1, 8, 10], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
+    state.board = ((46, 1, 8, 10), (0, 1, 2, 3), (0, 1, 2, 3), (0, 1, 2, 3))
     state.dice, state.turn = 2, 0
     assert get_movables(state) == [4]
     state = apply_move(state, 4)
-    assert state.board == [
-        [46, 1, 8, 12],
-        [0, 1, 2, 3],
-        [0, 1, 2, 3],
-        [0, 1, 2, 3],
-    ]
+    assert state.board == ((46, 1, 8, 12), (0, 1, 2, 3), (0, 1, 2, 3), (0, 1, 2, 3))
     state.dice = 5
     assert is_start(state) is True
     assert (
@@ -80,16 +75,11 @@ def test_board_1() -> None:
 
 def test_board_2() -> None:
     state = new_state()
-    state.board = [[10, 4, 2, 43], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
+    state.board = ((10, 4, 2, 43), (0, 1, 2, 3), (0, 1, 2, 3), (0, 1, 2, 3))
     state.dice, state.turn = 6, 0
     assert get_movables(state) == [1]
     state = apply_move(state, 1)
-    assert state.board == [
-        [16, 4, 2, 43],
-        [0, 1, 2, 3],
-        [0, 1, 2, 3],
-        [0, 1, 2, 3],
-    ]
+    assert state.board == ((16, 4, 2, 43), (0, 1, 2, 3), (0, 1, 2, 3), (0, 1, 2, 3))
     state.dice = 5
     assert is_start(state) is False
     assert (
@@ -113,16 +103,11 @@ def test_board_2() -> None:
 
 def test_board_3() -> None:
     state = new_state()
-    state.board = [[0, 7, 46, 15], [0, 34, 2, 3], [0, 1, 2, 3], [0, 1, 2, 19]]
+    state.board = ((0, 7, 46, 15), (0, 34, 2, 3), (0, 1, 2, 3), (0, 1, 2, 19))
     state.dice, state.turn = 2, 0
     assert get_movables(state) == [2, 4]
     state = apply_move(state, 2)
-    assert state.board == [
-        [0, 9, 46, 15],
-        [0, 34, 2, 3],
-        [0, 1, 2, 3],
-        [0, 1, 2, 3],
-    ]
+    assert state.board == ((0, 9, 46, 15), (0, 34, 2, 3), (0, 1, 2, 3), (0, 1, 2, 3))
     state.dice = 5
     assert is_start(state) is False
     assert (
@@ -146,16 +131,11 @@ def test_board_3() -> None:
 
 def test_board_4() -> None:
     state = new_state()
-    state.board = [[13, 43, 2, 3], [0, 1, 34, 3], [0, 1, 2, 3], [0, 29, 2, 3]]
+    state.board = ((13, 43, 2, 3), (0, 1, 34, 3), (0, 1, 2, 3), (0, 29, 2, 3))
     state.dice, state.turn = 6, 0
     assert get_movables(state) == [1, 3, 4]
     state = apply_move(state, 3)
-    assert state.board == [
-        [13, 43, 4, 3],
-        [0, 1, 2, 3],
-        [0, 1, 2, 3],
-        [0, 29, 2, 3],
-    ]
+    assert state.board == ((13, 43, 4, 3), (0, 1, 2, 3), (0, 1, 2, 3), (0, 29, 2, 3))
     state.dice = 3
     assert is_start(state) is False
     assert (
@@ -179,16 +159,11 @@ def test_board_4() -> None:
 
 def test_board_5() -> None:
     state = new_state()
-    state.board = [[0, 29, 2, 3], [13, 43, 2, 3], [0, 1, 34, 3], [0, 1, 2, 3]]
+    state.board = ((0, 29, 2, 3), (13, 43, 2, 3), (0, 1, 34, 3), (0, 1, 2, 3))
     state.dice, state.turn = 6, 1
     assert get_movables(state) == [1, 3, 4]
     state = apply_move(state, 4)
-    assert state.board == [
-        [0, 29, 2, 3],
-        [13, 43, 2, 4],
-        [0, 1, 2, 3],
-        [0, 1, 2, 3],
-    ]
+    assert state.board == ((0, 29, 2, 3), (13, 43, 2, 4), (0, 1, 2, 3), (0, 1, 2, 3))
     state.dice = 4
     assert is_start(state) is False
     assert (
@@ -270,7 +245,7 @@ def test_visualize_colored() -> None:
 
 def test_visualize_colored_winner() -> None:
     state = new_state()
-    state.board = [[44, 45, 46, 47], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
+    state.board = ((44, 45, 46, 47), (0, 1, 2, 3), (0, 1, 2, 3), (0, 1, 2, 3))
     state.turn = None
     state.winner = 0
 
@@ -283,7 +258,7 @@ def test_visualize_colored_winner() -> None:
 
 def test_three_sixes_rule() -> None:
     state = new_state()
-    state.board = [[4, 5, 6, 7], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
+    state.board = ((4, 5, 6, 7), (0, 1, 2, 3), (0, 1, 2, 3), (0, 1, 2, 3))
     state.turn = 0
     state.count_six = 0
 
@@ -305,7 +280,7 @@ def test_three_sixes_rule() -> None:
 
 def test_three_sixes_rule_reset_on_non_six() -> None:
     state = new_state()
-    state.board = [[4, 5, 6, 7], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
+    state.board = ((4, 5, 6, 7), (0, 1, 2, 3), (0, 1, 2, 3), (0, 1, 2, 3))
     state.turn = 0
     state.count_six = 0
 
@@ -327,7 +302,7 @@ def test_three_sixes_rule_reset_on_non_six() -> None:
 
 def test_three_starts_rule() -> None:
     state = new_state()
-    state.board = [[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
+    state.board = ((0, 1, 2, 3), (0, 1, 2, 3), (0, 1, 2, 3), (0, 1, 2, 3))
     state.turn = 0
     state.count_start = 0
 
@@ -350,7 +325,7 @@ def test_three_starts_rule() -> None:
 
 def test_three_starts_rule_reset_on_leaving_start() -> None:
     state = new_state()
-    state.board = [[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
+    state.board = ((0, 1, 2, 3), (0, 1, 2, 3), (0, 1, 2, 3), (0, 1, 2, 3))
     state.turn = 0
     state.count_start = 0
 
@@ -375,7 +350,7 @@ def test_three_starts_rule_reset_on_leaving_start() -> None:
 
 def test_three_starts_with_six_interaction() -> None:
     state = new_state()
-    state.board = [[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
+    state.board = ((0, 1, 2, 3), (0, 1, 2, 3), (0, 1, 2, 3), (0, 1, 2, 3))
     state.turn = 0
     state.count_start = 2
     state.count_six = 0
@@ -400,7 +375,7 @@ def test_three_starts_with_six_interaction() -> None:
 
 def test_count_six_reset_on_pass() -> None:
     state = new_state()
-    state.board = [[43, 45, 46, 47], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
+    state.board = ((43, 45, 46, 47), (0, 1, 2, 3), (0, 1, 2, 3), (0, 1, 2, 3))
     state.turn = 0
     state.count_six = 1
 


### PR DESCRIPTION
## Summary
- Add support for vacant player seats via `State.players`, with a `--players` CLI option to select participating seats
- Convert `State` to a dataclass and its methods to free functions
- Replace `State.previous` with an undo history list in the CLI
- Change `State.board` from a list of lists to a tuple of tuples
- Remove `copy_state` in favor of `dataclasses.replace`

## Test plan
- [x] `pytest` (32 passed)