### PR TITLE
Use mmap for random access to params_endgame.dat

### DIFF
--- a/src/hotaru.py
+++ b/src/hotaru.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import mmap
 import random
 import readline  # noqa: F401
 import struct
@@ -228,16 +229,14 @@ def in_theo(s: State) -> bool:
     )
 
 
-def eval_state_theo(filename: str, state: State, turn: int) -> float:
-    return read_bin(filename, index_state(state, turn))
+def eval_state_theo(mm: mmap.mmap, state: State, turn: int) -> float:
+    return read_bin(mm, index_state(state, turn))
 
 
-def read_bin(filename: str, index: int) -> float:
-    with open(filename, "rb") as f:
-        f.seek(index * 4)
-        r = struct.unpack("f", f.read(4))[0]
-        assert isinstance(r, float)
-        return r
+def read_bin(mm: mmap.mmap, index: int) -> float:
+    r = struct.unpack_from("f", mm, index * 4)[0]
+    assert isinstance(r, float)
+    return r
 
 
 def rank_pieces(positions: tuple[int, ...]) -> tuple[int, int, int]:
@@ -281,10 +280,15 @@ class HotaruEvaluator(Evaluator):
         if enable_midgame:
             with open("params_midgame.dat", "rb") as f:
                 self.params_midgame = f.read()
+        self.params_endgame: mmap.mmap | None = None
+        if enable_endgame:
+            with open("params_endgame.dat", "rb") as f:
+                self.params_endgame = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
         self.enable_endgame: bool = enable_endgame
 
     def score_theo(self, s: State, turn: int) -> float:
-        return 1 - 2 * eval_state_theo("params_endgame.dat", s, 1 if turn == 0 else 0)
+        assert self.params_endgame is not None
+        return 1 - 2 * eval_state_theo(self.params_endgame, s, 1 if turn == 0 else 0)
 
     def score(self, state: State, turn: int) -> float:
         assert self.params_midgame is not None

--- a/tests/test_hotaru.py
+++ b/tests/test_hotaru.py
@@ -494,6 +494,9 @@ def test_autoplay_2(run_cli: Callable[[list[str]], list[str]]) -> None:
     assert wins[1] == wins[3] == 0 and 800 < wins[0] < 1200 and 800 < wins[2] < 1200
 
 
+@pytest.mark.skipif(
+    not Path("params_endgame.dat").exists(), reason="`params_endgame.dat` not found"
+)
 def test_hotaru_evaluator_endgame_only_outside_theo() -> None:
     state = new_state()
     state.dice = 1


### PR DESCRIPTION
## Summary
- Replace per-lookup `open()`/`seek()`/`read()` of `params_endgame.dat` with an `mmap` opened once in `HotaruEvaluator.__init__`, avoiding repeated file opens on every endgame score lookup.

## Test plan
- [x] `uv run pytest`