### PR TITLE
Speed up CI with parallel tox jobs and tox-uv

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -18,13 +18,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v9
       with:
         python-version: 3.14
-    - name: Install tox
-      run: |
-        pip install -U pip
-        pip install -U tox
     - name: Run tox
-      run: tox -e ${{ matrix.env }}
+      run: uvx --with tox-uv tox -e ${{ matrix.env }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,7 +8,12 @@ on:
 
 jobs:
   tox:
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [ "3.14", "type", "lint", "format", "format_pyproject" ]
 
+    name: tox (${{ matrix.env }})
     runs-on: ubuntu-latest
 
     steps:
@@ -22,4 +27,4 @@ jobs:
         pip install -U pip
         pip install -U tox
     - name: Run tox
-      run: tox
+      run: tox -e ${{ matrix.env }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up uv
-      uses: astral-sh/setup-uv@v9
+      uses: astral-sh/setup-uv@v9.0.0
       with:
         python-version: 3.14
     - name: Run tox

--- a/README.md
+++ b/README.md
@@ -5,20 +5,18 @@ Rules are based on the Ludo implementation used on [PlayOK](https://playok.com/e
 
 ## Installation
 ```
-git clone https://github.com/mushitoriami/hotaru.git
-cd hotaru
-uv sync
+uv tool install git+https://github.com/mushitoriami/hotaru.git
 ```
 
 ## Usage
 Start the interactive CLI:
 ```
-uv run hotaru
+hotaru
 ```
 
 By default all four seats (0-3) participate. To play with fewer than four (minimum two), pass `--players` as a comma-separated list of seat indices:
 ```
-uv run hotaru --players 0,2
+hotaru --players 0,2
 ```
 
 Available commands at the `>` prompt:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ lint.select = [ "B", "C4", "E", "F", "I", "N", "SIM", "UP", "W" ]
 lint.ignore = [ "B011" ]
 
 [tool.tox]
-requires = [ "tox>=4.19" ]
+requires = [ "tox>=4.19", "tox-uv>=1.36.0,<2" ]
 env_list = [ "3.14", "type", "lint", "format", "format_pyproject" ]
 
 [tool.tox.env.format]


### PR DESCRIPTION
## Summary
- Split the single sequential tox job into a per-environment matrix so failures are visible per environment and jobs run in parallel
- Switch tox to tox-uv for faster env provisioning
- Document `uv tool install` as the README installation method

## Test plan
- [x] `uvx --with tox-uv tox -e format,lint,format_pyproject` passes locally